### PR TITLE
[#13] Add secret/public keypair generation from seed

### DIFF
--- a/crypto-sodium/CHANGELOG.md
+++ b/crypto-sodium/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Keypair generation from seed: `Crypto.Sign` and `Crypto.Encrypt.Public`
+
 ### Added
 
 * `sodiumInit`

--- a/crypto-sodium/CHANGELOG.md
+++ b/crypto-sodium/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-* Keypair generation from seed: `Crypto.Sign` and `Crypto.Encrypt.Public`
-
 ### Added
 
 * `sodiumInit`
@@ -12,3 +10,4 @@
 * MAC: `Crypto.Mac`, `Crypto.Mac.Lazy`
 * Random nonce generation: `Crypto.Nonce`
 * Public-key signatures: `Crypto.Sign`
+* Keypair generation from seed: `Crypto.Sign` and `Crypto.Encrypt.Public`

--- a/crypto-sodium/crypto-sodium.cabal
+++ b/crypto-sodium/crypto-sodium.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.3.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 18904259dc25423e15ecf6c62de6ccea4fedf93e3ebab101001b8ef38c63b169
+-- hash: b6b0de8198a9a37175769ca414c31672ff13aebc9184ed123a6e3715e7677462
 
 name:           crypto-sodium
 version:        0.0.3.1
@@ -106,12 +106,14 @@ test-suite test
   type: exitcode-stdio-1.0
   main-is: Test.hs
   other-modules:
+      Test.Crypto.Encrypt.Public
       Test.Crypto.Encrypt.Symmetric
       Test.Crypto.Gen
       Test.Crypto.Key.Derivation
       Test.Crypto.Nonce
       Test.Crypto.Pwhash
       Test.Crypto.Random
+      Test.Crypto.Sign
       Paths_crypto_sodium
   hs-source-dirs:
       test

--- a/crypto-sodium/lib/Crypto/Encrypt/Public.hs
+++ b/crypto-sodium/lib/Crypto/Encrypt/Public.hs
@@ -55,7 +55,7 @@ import Data.ByteArray.Sized as Sized (SizedByteArray, alloc, allocRet)
 import Data.ByteString (ByteString)
 import Data.Functor (void)
 import Data.Proxy (Proxy(..))
-import System.IO.Unsafe (unsafeDupablePerformIO)
+import System.IO.Unsafe (unsafePerformIO)
 
 import qualified Libsodium as Na
 
@@ -134,8 +134,6 @@ type Seed a = SizedByteArray Na.CRYPTO_BOX_SEEDBYTES a
 
 
 -- | Generate a new 'SecretKey' together with its 'PublicKey' from a given seed.
---
--- The given seed must be @Na.CRYPTO_BOX_SEEDBYTES@ bytes long.
 keypairFromSeed
   :: ByteArrayAccess seed
   => Seed seed
@@ -149,10 +147,8 @@ keypairFromSeed seed = do
 
 -- | Generate a new 'SecretKey' together with its 'PublicKey' from a given seed,
 -- in a pure context.
---
--- The given seed must be @Na.CRYPTO_BOX_SEEDBYTES@ bytes long.
 unsafeKeypairFromSeed
   :: ByteArrayAccess seed
   => Seed seed
   -> (PublicKey ByteString, SecretKey ScrubbedBytes)
-unsafeKeypairFromSeed = unsafeDupablePerformIO . keypairFromSeed
+unsafeKeypairFromSeed = unsafePerformIO . keypairFromSeed

--- a/crypto-sodium/lib/Crypto/Encrypt/Public.hs
+++ b/crypto-sodium/lib/Crypto/Encrypt/Public.hs
@@ -39,6 +39,7 @@ module Crypto.Encrypt.Public
   , toSecretKey
   , keypair
   , keypairFromSeed
+  , unsafeKeypairFromSeed
 
   -- * Nonce
   , Nonce
@@ -50,15 +51,16 @@ module Crypto.Encrypt.Public
   ) where
 
 import Data.ByteArray (ByteArray, ByteArrayAccess, ScrubbedBytes, withByteArray)
-import Data.ByteArray.Sized as Sized (alloc, allocRet)
+import Data.ByteArray.Sized as Sized (SizedByteArray, alloc, allocRet)
 import Data.ByteString (ByteString)
 import Data.Functor (void)
 import Data.Proxy (Proxy(..))
-import NaCl.Box
-  (Nonce, PublicKey, SecretKey, keypair, toNonce, toPublicKey, toSecretKey)
+import System.IO.Unsafe (unsafeDupablePerformIO)
 
 import qualified Libsodium as Na
 
+import NaCl.Box
+  (Nonce, PublicKey, SecretKey, keypair, toNonce, toPublicKey, toSecretKey)
 import qualified NaCl.Box as NaCl.Box
 
 
@@ -121,10 +123,22 @@ decrypt
 decrypt = NaCl.Box.open
 
 
+-- | Seed for deterministically generating a keypair.
+--
+-- In accordance with Libsodium's documentation, the seed must be of size
+-- @Na.CRYPTO_BOX_SEEDBYTES@.
+--
+-- This type is parametrised by the actual data type that contains
+-- bytes. This can be, for example, a @ByteString@.
+type Seed a = SizedByteArray Na.CRYPTO_BOX_SEEDBYTES a
+
+
 -- | Generate a new 'SecretKey' together with its 'PublicKey' from a given seed.
+--
+-- The given seed must be @Na.CRYPTO_BOX_SEEDBYTES@ bytes long.
 keypairFromSeed
   :: ByteArrayAccess seed
-  => seed
+  => Seed seed
   -> IO (PublicKey ByteString, SecretKey ScrubbedBytes)
 keypairFromSeed seed = do
   allocRet Proxy $ \skPtr ->
@@ -132,3 +146,13 @@ keypairFromSeed seed = do
     withByteArray seed $ \sdPtr ->
     -- always returns 0, so we don’t check it
     void $ Na.crypto_box_seed_keypair pkPtr skPtr sdPtr
+
+-- | Generate a new 'SecretKey' together with its 'PublicKey' from a given seed,
+-- in a pure context.
+--
+-- The given seed must be @Na.CRYPTO_BOX_SEEDBYTES@ bytes long.
+unsafeKeypairFromSeed
+  :: ByteArrayAccess seed
+  => Seed seed
+  -> (PublicKey ByteString, SecretKey ScrubbedBytes)
+unsafeKeypairFromSeed = unsafeDupablePerformIO . keypairFromSeed

--- a/crypto-sodium/lib/Crypto/Sign.hs
+++ b/crypto-sodium/lib/Crypto/Sign.hs
@@ -49,7 +49,7 @@ import Data.ByteString (ByteString)
 import Data.ByteArray.Sized (SizedByteArray, alloc, allocRet)
 import Data.Functor (void)
 import Data.Proxy (Proxy(..))
-import System.IO.Unsafe (unsafeDupablePerformIO)
+import System.IO.Unsafe (unsafePerformIO)
 
 import qualified Libsodium as Na
 
@@ -59,16 +59,14 @@ import NaCl.Sign
 -- | Seed for deterministically generating a keypair.
 --
 -- In accordance with Libsodium's documentation, the seed must be of size
--- @Na.CRYPTO_BOX_SEEDBYTES@.
+-- @Na.CRYPTO_SIGN_SEEDBYTES@.
 --
 -- This type is parametrised by the actual data type that contains
 -- bytes. This can be, for example, a @ByteString@.
-type Seed a = SizedByteArray Na.CRYPTO_BOX_SEEDBYTES a
+type Seed a = SizedByteArray Na.CRYPTO_SIGN_SEEDBYTES a
 
 
 -- | Generate a new 'SecretKey' together with its 'PublicKey' from a given seed.
---
--- The given seed must be @Na.CRYPTO_BOX_SEEDBYTES@ bytes long.
 keypairFromSeed
   :: ByteArrayAccess seed
   => Seed seed
@@ -82,10 +80,8 @@ keypairFromSeed seed = do
 
 -- | Generate a new 'SecretKey' together with its 'PublicKey' from a given seed,
 -- in a pure context.
---
--- The given seed must be @Na.CRYPTO_BOX_SEEDBYTES@ bytes long.
 unsafeKeypairFromSeed
   :: ByteArrayAccess seed
   => Seed seed
   -> (PublicKey ByteString, SecretKey ScrubbedBytes)
-unsafeKeypairFromSeed = unsafeDupablePerformIO . keypairFromSeed
+unsafeKeypairFromSeed = unsafePerformIO . keypairFromSeed

--- a/crypto-sodium/test/Test/Crypto/Encrypt/Public.hs
+++ b/crypto-sodium/test/Test/Crypto/Encrypt/Public.hs
@@ -9,6 +9,7 @@ import Hedgehog (Property, forAll, property, tripping)
 import Hedgehog.Internal.Property (forAllT)
 
 import Control.Monad.IO.Class (liftIO)
+import Data.ByteArray.Sized (unsafeSizedByteArray)
 import Data.ByteString (ByteString)
 
 import qualified Libsodium as Na
@@ -28,8 +29,8 @@ seedSize = R.singleton $ fromIntegral Na.crypto_box_seedbytes
 
 hprop_encode_decode_seed :: Property
 hprop_encode_decode_seed = property $ do
-    seed1 <- forAll $ G.bytes seedSize
-    seed2 <- forAll $ G.bytes seedSize
+    seed1 <- fmap unsafeSizedByteArray . forAll $ G.bytes seedSize
+    seed2 <- fmap unsafeSizedByteArray . forAll $ G.bytes seedSize
     (pkS, skS) <- forAllT . liftIO $ Public.keypairFromSeed seed1
     (pkR, skR) <- forAllT . liftIO $ Public.keypairFromSeed seed2
     nonceBytes <- forAll $ G.bytes nonceSize

--- a/crypto-sodium/test/Test/Crypto/Encrypt/Public.hs
+++ b/crypto-sodium/test/Test/Crypto/Encrypt/Public.hs
@@ -5,11 +5,11 @@
 -- | “Integration” tests: using Public with our helpers.
 module Test.Crypto.Encrypt.Public where
 
-import Hedgehog (Property, forAll, property, tripping)
+import Hedgehog (Property, evalMaybe, forAll, property, tripping)
 import Hedgehog.Internal.Property (forAllT)
 
 import Control.Monad.IO.Class (liftIO)
-import Data.ByteArray.Sized (unsafeSizedByteArray)
+import Data.ByteArray.Sized (sizedByteArray)
 import Data.ByteString (ByteString)
 
 import qualified Libsodium as Na
@@ -29,8 +29,8 @@ seedSize = R.singleton $ fromIntegral Na.crypto_box_seedbytes
 
 hprop_encode_decode_seed :: Property
 hprop_encode_decode_seed = property $ do
-    seed1 <- fmap unsafeSizedByteArray . forAll $ G.bytes seedSize
-    seed2 <- fmap unsafeSizedByteArray . forAll $ G.bytes seedSize
+    seed1 <- evalMaybe . sizedByteArray =<< forAll (G.bytes seedSize)
+    seed2 <- evalMaybe . sizedByteArray =<< forAll (G.bytes seedSize)
     (pkS, skS) <- forAllT . liftIO $ Public.keypairFromSeed seed1
     (pkR, skR) <- forAllT . liftIO $ Public.keypairFromSeed seed2
     nonceBytes <- forAll $ G.bytes nonceSize

--- a/crypto-sodium/test/Test/Crypto/Encrypt/Public.hs
+++ b/crypto-sodium/test/Test/Crypto/Encrypt/Public.hs
@@ -1,0 +1,42 @@
+-- SPDX-FileCopyrightText: 2021 Serokell
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+-- | “Integration” tests: using Public with our helpers.
+module Test.Crypto.Encrypt.Public where
+
+import Hedgehog (Property, forAll, property, tripping)
+import Hedgehog.Internal.Property (forAllT)
+
+import Control.Monad.IO.Class (liftIO)
+import Data.ByteString (ByteString)
+
+import qualified Libsodium as Na
+
+import qualified Hedgehog.Gen as G
+import qualified Hedgehog.Range as R
+
+import qualified Crypto.Encrypt.Public as Public
+
+
+nonceSize :: R.Range Int
+nonceSize = R.singleton $ fromIntegral Na.crypto_box_noncebytes
+
+seedSize :: R.Range Int
+seedSize = R.singleton $ fromIntegral Na.crypto_box_seedbytes
+
+
+hprop_encode_decode_seed :: Property
+hprop_encode_decode_seed = property $ do
+    seed1 <- forAll $ G.bytes seedSize
+    seed2 <- forAll $ G.bytes seedSize
+    (pkS, skS) <- forAllT . liftIO $ Public.keypairFromSeed seed1
+    (pkR, skR) <- forAllT . liftIO $ Public.keypairFromSeed seed2
+    nonceBytes <- forAll $ G.bytes nonceSize
+    let Just nonce = Public.toNonce nonceBytes
+    msg <- forAll $ G.bytes (R.linear 0 1_000)
+    tripping msg (encodeBs pkR skS nonce) (decodeBs skR pkS nonce)
+  where
+    -- We need to specify the type of the cyphertext as it is polymorphic
+    encodeBs pkR skS nonce msg = Public.encrypt pkR skS nonce msg :: ByteString
+    decodeBs skR pkS nonce ct = Public.decrypt skR pkS nonce ct :: Maybe ByteString

--- a/crypto-sodium/test/Test/Crypto/Sign.hs
+++ b/crypto-sodium/test/Test/Crypto/Sign.hs
@@ -9,6 +9,7 @@ import Hedgehog (Property, forAll, property, tripping)
 import Hedgehog.Internal.Property (forAllT)
 
 import Control.Monad.IO.Class (liftIO)
+import Data.ByteArray.Sized (unsafeSizedByteArray)
 import Data.ByteString (ByteString)
 
 import qualified Hedgehog.Gen as G
@@ -25,7 +26,7 @@ seedSize = R.singleton $ fromIntegral Na.crypto_box_seedbytes
 
 hprop_encode_decode_seed :: Property
 hprop_encode_decode_seed = property $ do
-    seed <- forAll $ G.bytes seedSize
+    seed <- fmap unsafeSizedByteArray . forAll $ G.bytes seedSize
     (pk, sk) <- forAllT . liftIO $ Sign.keypairFromSeed seed
     msg <- forAll $ G.bytes (R.linear 0 1_000)
     tripping msg (encodeBs sk) (decodeBs pk)

--- a/crypto-sodium/test/Test/Crypto/Sign.hs
+++ b/crypto-sodium/test/Test/Crypto/Sign.hs
@@ -1,0 +1,35 @@
+-- SPDX-FileCopyrightText: 2021 Serokell
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+-- | “Integration” tests: using Sign with our helpers.
+module Test.Crypto.Sign where
+
+import Hedgehog (Property, forAll, property, tripping)
+import Hedgehog.Internal.Property (forAllT)
+
+import Control.Monad.IO.Class (liftIO)
+import Data.ByteString (ByteString)
+
+import qualified Hedgehog.Gen as G
+import qualified Hedgehog.Range as R
+
+import qualified Libsodium as Na
+
+import qualified Crypto.Sign as Sign
+
+
+seedSize :: R.Range Int
+seedSize = R.singleton $ fromIntegral Na.crypto_box_seedbytes
+
+
+hprop_encode_decode_seed :: Property
+hprop_encode_decode_seed = property $ do
+    seed <- forAll $ G.bytes seedSize
+    (pk, sk) <- forAllT . liftIO $ Sign.keypairFromSeed seed
+    msg <- forAll $ G.bytes (R.linear 0 1_000)
+    tripping msg (encodeBs sk) (decodeBs pk)
+  where
+    -- We need to specify the type of the signed msg as it is polymorphic
+    encodeBs sk msg = Sign.create sk msg :: ByteString
+    decodeBs pk ct = Sign.open pk ct :: Maybe ByteString

--- a/crypto-sodium/test/Test/Crypto/Sign.hs
+++ b/crypto-sodium/test/Test/Crypto/Sign.hs
@@ -5,11 +5,11 @@
 -- | “Integration” tests: using Sign with our helpers.
 module Test.Crypto.Sign where
 
-import Hedgehog (Property, forAll, property, tripping)
+import Hedgehog (Property, evalMaybe, forAll, property, tripping)
 import Hedgehog.Internal.Property (forAllT)
 
 import Control.Monad.IO.Class (liftIO)
-import Data.ByteArray.Sized (unsafeSizedByteArray)
+import Data.ByteArray.Sized (sizedByteArray)
 import Data.ByteString (ByteString)
 
 import qualified Hedgehog.Gen as G
@@ -21,12 +21,12 @@ import qualified Crypto.Sign as Sign
 
 
 seedSize :: R.Range Int
-seedSize = R.singleton $ fromIntegral Na.crypto_box_seedbytes
+seedSize = R.singleton $ fromIntegral Na.crypto_sign_seedbytes
 
 
 hprop_encode_decode_seed :: Property
 hprop_encode_decode_seed = property $ do
-    seed <- fmap unsafeSizedByteArray . forAll $ G.bytes seedSize
+    seed <- evalMaybe . sizedByteArray =<< forAll (G.bytes seedSize)
     (pk, sk) <- forAllT . liftIO $ Sign.keypairFromSeed seed
     msg <- forAll $ G.bytes (R.linear 0 1_000)
     tripping msg (encodeBs sk) (decodeBs pk)

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-resolver: lts-14.25
+resolver: lts-17.2
 packages:
   - NaCl
   - crypto-sodium

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,9 +12,6 @@ packages:
   original:
     hackage: libsodium-1.0.18.1
 - completed:
-    cabal-file:
-      size: 35273
-      sha256: da6a45807355e43f85ff8aef99e9e9e1ab291d31a82bb7f1a62ec7406950301b
     name: streamly
     version: 0.7.2
     git: https://github.com/composewell/streamly.git
@@ -34,7 +31,7 @@ packages:
     hackage: fusion-plugin-types-0.1.0@sha256:0f11bbc445ab8ae3dbbb3d5d2ea198bdb1ac020518b7f4f7579035dc89182438,1506
 snapshots:
 - completed:
-    size: 524163
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/25.yaml
-    sha256: 97548b4e927a8a862d4a203687ca18a3f5d2ae75b4b72c946fb29c17df1a5082
-  original: lts-14.25
+    size: 563099
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/2.yaml
+    sha256: 92b1a17e31d0a978fca4bf270305d4d1dd8092271bf60eafbc9349c890854026
+  original: lts-17.2


### PR DESCRIPTION
Exposes `crypto_box_seed_keypair` and `crypto_sign_seed_keypair`, both in `NaCl` and consequently in `crypto-sodium`.

Closes #13.