### PR TITLE
CI: bump dependencies, use flake registry

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,22 +1,101 @@
 {
   "nodes": {
-    "flake-compat": {
+    "HTTP": {
       "flake": false,
       "locked": {
-        "lastModified": 1627557337,
-        "narHash": "sha256-S/Aab7AcDS+MopcnkEWu0j3qOGLLaMw1E8VWWQOD+Q8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "c6f3b635321160c629b74fefc88c807b59a51646",
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
+        "owner": "phadej",
+        "repo": "HTTP",
         "type": "github"
       }
     },
+    "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-sDbrmur9Zfp4mPKohCD8IDZfXJ0Tjxpmr2R+kg5PpSY=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1622475795,
+        "narHash": "sha256-chwTL304Cav+7p38d9mcb+egABWmxo2Aq+xgVBgEb/U=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-compat",
+        "type": "indirect"
+      }
+    },
     "flake-utils": {
+      "locked": {
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "flake-utils_2": {
       "locked": {
         "lastModified": 1623875721,
         "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
@@ -31,57 +110,135 @@
         "type": "github"
       }
     },
-    "hackage": {
+    "ghc-8.6.5-iohk": {
       "flake": false,
       "locked": {
-        "lastModified": 1627348315,
-        "narHash": "sha256-Q9mxANCL8iboRLigWuLM4fBoeSCzoZ22Pw1SnasV8aU=",
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
         "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "d8e45c5ae00c01db79222249fd7128592c80d76d",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "repo": "hackage.nix",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
         "type": "github"
+      }
+    },
+    "hackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1630631488,
+        "narHash": "sha256-lT5XsHnh/MelZmKSMFZ8oP/eGY5vFv+BGSibkhHV5OQ=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "c4a3c64af0a33052ba93128fbdc40a2ee1335979",
+        "type": "github"
+      },
+      "original": {
+        "id": "hackage",
+        "type": "indirect"
       }
     },
     "haskell-nix": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
+        "HTTP": "HTTP",
+        "cabal-32": "cabal-32",
+        "cabal-34": "cabal-34",
+        "cardano-shell": "cardano-shell",
+        "flake-utils": "flake-utils_2",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "hackage": [
+          "hackage"
         ],
+        "hpc-coveralls": "hpc-coveralls",
+        "nix-tools": "nix-tools",
+        "nixpkgs": [
+          "haskell-nix",
+          "nixpkgs-2105"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003",
         "nixpkgs-2009": "nixpkgs-2009",
         "nixpkgs-2105": "nixpkgs-2105",
-        "nixpkgs-unstable": "nixpkgs-unstable"
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "old-ghc-nix": "old-ghc-nix",
+        "stackage": [
+          "stackage"
+        ]
       },
       "locked": {
-        "lastModified": 1625015634,
-        "narHash": "sha256-bM9bdCCvOye16WFWgZ+0mzu7cKiqswx4rQCbfq3Co4g=",
+        "lastModified": 1630978517,
+        "narHash": "sha256-4NOhGRVH9eu/cpADkSHxMqaAbHVsV7vrDDjjCul0jJA=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "81fb54dbfdd350b6ad8271973545f1b668975394",
+        "rev": "a4e105dcdb6d2b9d0627b8f0b893cec80485c14e",
+        "type": "github"
+      },
+      "original": {
+        "id": "haskell-nix",
+        "type": "indirect"
+      }
+    },
+    "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "nix-tools": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1626997434,
+        "narHash": "sha256-1judQmP298ao6cGUNxcGhcAXHOnA9qSLvWk/ZtoUL7w=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "c8c5e6a6fbb12a73598d1a434984a36e880ce3cf",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "rev": "81fb54dbfdd350b6ad8271973545f1b668975394",
+        "repo": "nix-tools",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1622223326,
-        "narHash": "sha256-kVb9eGqc+JLENFcctmPyQml1y0xZqvBnykT5niwy/js=",
+        "lastModified": 1631273642,
+        "narHash": "sha256-LeD8U6LijyPHgr5ECLk7cobb4EkgPyPJJjxcYNi8noo=",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "cf67659f17ba891def51bd718b2722a4065fcda3",
+        "rev": "1714a2ead1a18678afa3cbf75dff3f024c579061",
         "type": "github"
       },
       "original": {
-        "owner": "serokell",
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-2003": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -97,40 +254,57 @@
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-20.09-darwin",
         "repo": "nixpkgs",
-        "rev": "46d1c3f28ca991601a53e9a14fdd53fcd3dd8416",
         "type": "github"
       }
     },
     "nixpkgs-2105": {
       "locked": {
-        "lastModified": 1624291665,
-        "narHash": "sha256-kNkaoa3dai9WOi7fsPklCCWZ8hRAkXx0ZUhpYKShyUk=",
+        "lastModified": 1630481079,
+        "narHash": "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3c6f3f84af60a8ed5b8a79cf3026b7630fcdefb8",
+        "rev": "110a2c9ebbf5d4a94486854f18a37a938cfacbbb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
         "repo": "nixpkgs",
-        "rev": "3c6f3f84af60a8ed5b8a79cf3026b7630fcdefb8",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1623862044,
-        "narHash": "sha256-mY7nldu9Wl/Yb0qMPihZrWw0bRWXNsk6iyYztw/6F6Y=",
+        "lastModified": 1628785280,
+        "narHash": "sha256-2B5eMrEr6O8ff2aQNeVxTB+9WrGE80OB4+oM6T7fOcc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0747387223edf1aa5beaedf48983471315d95e16",
+        "rev": "6525bbc06a39f26750ad8ee0d40000ddfdc24acb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "0747387223edf1aa5beaedf48983471315d95e16",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1621819714,
+        "narHash": "sha256-EJCnYQSWk7FRLwS0lZgTWIiQ6pcvDX1VuD6LGD4Uwzs=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "f089a6f090cdb35fcf95f865fc6a31ba6b3ac4eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master2",
+        "repo": "old-ghc-nix",
         "type": "github"
       }
     },
@@ -147,17 +321,16 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1627261364,
-        "narHash": "sha256-TeJonXKgV4DDYqeZ/IRls2nJNKGer7Ur8OIXJcZ8wWI=",
+        "lastModified": 1630545275,
+        "narHash": "sha256-LrU8BvcrE6QJK9EcUPsX5x3v5qZLoluvmW7phXi7TIg=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "14d142057ccd35d4e39c765251c0ec52aab1dad0",
+        "rev": "8d07cc6c73717ba19304e6b9231a88504d0846b4",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "type": "github"
+        "id": "stackage",
+        "type": "indirect"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,43 +5,24 @@
 {
   description = "Easy-and-safe-to-use high-level cryptographic primitives.";
 
+  nixConfig = {
+    flake-registry = "https://github.com/serokell/flake-registry/raw/master/flake-registry.json";
+  };
+
   inputs = {
-    nixpkgs.url = "github:serokell/nixpkgs";
-
-    hackage = {
-      url = "github:input-output-hk/hackage.nix";
-      flake = false;
-    };
-    stackage = {
-      url = "github:input-output-hk/stackage.nix";
-      flake = false;
-    };
+    flake-compat.flake = false;
     haskell-nix = {
-      url = "github:input-output-hk/haskell.nix/81fb54dbfdd350b6ad8271973545f1b668975394";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.hackage.follows = "hackage";
+      inputs.stackage.follows = "stackage";
     };
-
-    flake-utils.url = "github:numtide/flake-utils";
-
-    flake-compat = {
-      url = "github:edolstra/flake-compat";
-      flake = false;
-    };
+    hackage.flake = false;
+    stackage.flake = false;
   };
 
   outputs = { self, nixpkgs, hackage, stackage, haskell-nix, flake-utils, flake-compat }:
   flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
     let
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [
-          (haskell-nix.internal.overlaysOverrideable {
-            sourcesOverride = haskell-nix.internal.sources // {
-              inherit hackage stackage;
-            };
-          }).combined-eval-on-build
-        ];
-      };
+      pkgs = nixpkgs.legacyPackages.${system}.extend haskell-nix.overlay;
 
       inherit (nixpkgs.lib)
         flip isDerivation pipe


### PR DESCRIPTION
Update dependencies used by CI, to keep them up to date.

Related issue: https://issues.serokell.io/issue/OPS-1269