### PR TITLE
fix: Add type-level constraing on BLAKE2b key size

### DIFF
--- a/crypto-sodium/CHANGELOG.md
+++ b/crypto-sodium/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Random bytes generation: `Crypto.Sodium.Random`
 * Key derivation: `Crypto.Sodium.Key.derive` and `Crypto.Sodium.Key.rederive`
 * MAC: `Crypto.Sodium.Mac`, `Crypto.Sodium.Mac.Lazy`
-* Random nonce generation: `Crypto.Sodium.Nonce`
+* Nonces and salts: `Crypto.Sodium.Nonce`, `Crypto.Sodium.Salt`
 * Public-key signatures: `Crypto.Sodium.Sign`
 * Keypair generation from seed: `Crypto.Sodium.Sign` and `Crypto.Sodium.Encrypt.Public`
 * Hash: `Crypto.Sodium.Hash.blake2b`, `Crypto.Sodium.Hash.blake2bWithKey`, `Crypto.Sodium.Hash.sha256`, `Crypto.Sodium.Hash.sha512`

--- a/crypto-sodium/crypto-sodium.cabal
+++ b/crypto-sodium/crypto-sodium.cabal
@@ -85,6 +85,7 @@ library
       Crypto.Sodium.Nonce
       Crypto.Sodium.Pwhash.Internal
       Crypto.Sodium.Random
+      Crypto.Sodium.Salt
       Crypto.Sodium.Sign
   other-modules:
       Paths_crypto_sodium
@@ -114,6 +115,8 @@ library
     , memory >=0.14.15 && <0.17
     , random >=1.0 && <1.3
     , safe-exceptions ==0.1.*
+    , template-haskell >=2.8.0.0 && <2.19
+    , text >=0.1 && <1.3
   default-language: Haskell2010
 
 test-suite test
@@ -128,6 +131,7 @@ test-suite test
       Test.Crypto.Sodium.Nonce
       Test.Crypto.Sodium.Pwhash
       Test.Crypto.Sodium.Random
+      Test.Crypto.Sodium.Salt
       Test.Crypto.Sodium.Sign
       Paths_crypto_sodium
   hs-source-dirs:

--- a/crypto-sodium/crypto-sodium.cabal
+++ b/crypto-sodium/crypto-sodium.cabal
@@ -117,6 +117,7 @@ library
     , safe-exceptions ==0.1.*
     , template-haskell >=2.16.0.0 && <2.19
     , text >=0.1 && <1.3
+    , th-compat >=0.1.2 && <0.2
   default-language: Haskell2010
 
 test-suite test

--- a/crypto-sodium/crypto-sodium.cabal
+++ b/crypto-sodium/crypto-sodium.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.5.
 --
 -- see: https://github.com/sol/hpack
 
@@ -115,7 +115,7 @@ library
     , memory >=0.14.15 && <0.17
     , random >=1.0 && <1.3
     , safe-exceptions ==0.1.*
-    , template-haskell >=2.8.0.0 && <2.19
+    , template-haskell >=2.16.0.0 && <2.19
     , text >=0.1 && <1.3
   default-language: Haskell2010
 

--- a/crypto-sodium/lib/Crypto/Sodium/Hash.hs
+++ b/crypto-sodium/lib/Crypto/Sodium/Hash.hs
@@ -63,7 +63,7 @@ blake2b
   -> I.HashBlake2b len hashBytes
 blake2b msg = unsafePerformIO $ I.blake2b noKey msg
   where
-    noKey :: Maybe (SizedByteArray Na.CRYPTO_GENERICHASH_KEYBYTES Bytes)
+    noKey :: Maybe (SizedByteArray 0 Bytes)
     noKey = Nothing
 
 -- | Hash a message using BLAKE2b with a key.

--- a/crypto-sodium/lib/Crypto/Sodium/Hash.hs
+++ b/crypto-sodium/lib/Crypto/Sodium/Hash.hs
@@ -34,6 +34,7 @@ module Crypto.Sodium.Hash
   ) where
 
 import Data.ByteArray (ByteArray, ByteArrayAccess, Bytes)
+import Data.ByteArray.Sized (SizedByteArray)
 import GHC.TypeNats (KnownNat, type (<=))
 import NaCl.Hash (HashSha256, HashSha512, sha256, sha512)
 import System.IO.Unsafe (unsafePerformIO)
@@ -60,28 +61,40 @@ blake2b
       )
   => pt  -- ^ Message to hash
   -> I.HashBlake2b len hashBytes
-blake2b msg = unsafePerformIO $ I.blake2b (Nothing :: Maybe Bytes) msg
+blake2b msg = unsafePerformIO $ I.blake2b noKey msg
+  where
+    noKey :: Maybe (SizedByteArray Na.CRYPTO_GENERICHASH_KEYBYTES Bytes)
+    noKey = Nothing
 
 -- | Hash a message using BLAKE2b with a key.
 --
 -- @
+-- key <- 'Crypto.Sodium.Key.generate' @32
+--
+-- -- ...
+--
 -- hash128_keyed = Hash.'blake2bWithKey' \@16 key message
 -- hash256_keyed = Hash.'blake2bWithKey' \@32 key message
 -- hash512_keyed = Hash.'blake2bWithKey' \@64 key message
 -- @
 --
--- *   @key@ is the BLAKE2b key.
+-- *   @key@ is the key used when hashing. See "Crypto.Sodium.Key" for how
+--     to get one.
+--
 -- *   @message@ is the data you are hashing.
 blake2bWithKey
-  ::  forall len hashBytes pt key.
-      ( ByteArrayAccess pt
-      , ByteArrayAccess key
+  ::  forall outLen hashBytes pt keyBytes keyLen.
+      ( ByteArrayAccess keyBytes
+      , ByteArrayAccess pt
       , ByteArray hashBytes
-      , KnownNat len
-      , Na.CRYPTO_GENERICHASH_BYTES_MIN <= len
-      , len <= Na.CRYPTO_GENERICHASH_BYTES_MAX
+      , KnownNat keyLen
+      , Na.CRYPTO_GENERICHASH_KEYBYTES_MIN <= keyLen
+      , keyLen <= Na.CRYPTO_GENERICHASH_KEYBYTES_MAX
+      , KnownNat outLen
+      , Na.CRYPTO_GENERICHASH_BYTES_MIN <= outLen
+      , outLen <= Na.CRYPTO_GENERICHASH_BYTES_MAX
       )
-  => key -- ^ Hash key
+  => SizedByteArray keyLen keyBytes -- ^ Hash key
   -> pt  -- ^ Message to hash
-  -> I.HashBlake2b len hashBytes
+  -> I.HashBlake2b outLen hashBytes
 blake2bWithKey key msg = unsafePerformIO $ I.blake2b (Just key) msg

--- a/crypto-sodium/lib/Crypto/Sodium/Hash.hs
+++ b/crypto-sodium/lib/Crypto/Sodium/Hash.hs
@@ -88,7 +88,6 @@ blake2bWithKey
       , ByteArrayAccess pt
       , ByteArray hashBytes
       , KnownNat keyLen
-      , Na.CRYPTO_GENERICHASH_KEYBYTES_MIN <= keyLen
       , keyLen <= Na.CRYPTO_GENERICHASH_KEYBYTES_MAX
       , KnownNat outLen
       , Na.CRYPTO_GENERICHASH_BYTES_MIN <= outLen

--- a/crypto-sodium/lib/Crypto/Sodium/Hash/Internal.hs
+++ b/crypto-sodium/lib/Crypto/Sodium/Hash/Internal.hs
@@ -31,23 +31,26 @@ type HashBlake2b len a = SizedByteArray len a
 
 -- | Hash a message using BLAKE2b.
 blake2b
-  ::  forall len hashBytes pt key.
-      ( ByteArrayAccess pt
-      , ByteArrayAccess key
+  ::  forall outLen hashBytes pt keyBytes keyLen.
+      ( ByteArrayAccess keyBytes
+      , ByteArrayAccess pt
       , ByteArray hashBytes
-      , KnownNat len
-      , Na.CRYPTO_GENERICHASH_BYTES_MIN <= len
-      , len <= Na.CRYPTO_GENERICHASH_BYTES_MAX
+      , KnownNat keyLen
+      , Na.CRYPTO_GENERICHASH_KEYBYTES_MIN <= keyLen
+      , keyLen <= Na.CRYPTO_GENERICHASH_KEYBYTES_MAX
+      , KnownNat outLen
+      , Na.CRYPTO_GENERICHASH_BYTES_MIN <= outLen
+      , outLen <= Na.CRYPTO_GENERICHASH_BYTES_MAX
       )
-  => Maybe key -- ^ Hash key
+  => Maybe (SizedByteArray keyLen keyBytes) -- ^ Hash key
   -> pt  -- ^ Message to hash
-  -> IO (HashBlake2b len hashBytes)
+  -> IO (HashBlake2b outLen hashBytes)
 blake2b key msg = do
   (_ret, hash) <-
-    allocRet @len Proxy $ \hashPtr ->
+    allocRet @outLen Proxy $ \hashPtr ->
     withByteArray msg $ \msgPtr ->
     withKey $ \keyPtr ->
-      Na.crypto_generichash_blake2b hashPtr (fromIntegral $ natVal @len Proxy)
+      Na.crypto_generichash_blake2b hashPtr (fromIntegral $ natVal @outLen Proxy)
         msgPtr (fromIntegral $ length msg)
         keyPtr keyLen
   -- _ret can be only 0, so we don’t check it

--- a/crypto-sodium/lib/Crypto/Sodium/Hash/Internal.hs
+++ b/crypto-sodium/lib/Crypto/Sodium/Hash/Internal.hs
@@ -36,7 +36,6 @@ blake2b
       , ByteArrayAccess pt
       , ByteArray hashBytes
       , KnownNat keyLen
-      , Na.CRYPTO_GENERICHASH_KEYBYTES_MIN <= keyLen
       , keyLen <= Na.CRYPTO_GENERICHASH_KEYBYTES_MAX
       , KnownNat outLen
       , Na.CRYPTO_GENERICHASH_BYTES_MIN <= outLen

--- a/crypto-sodium/lib/Crypto/Sodium/Salt.hs
+++ b/crypto-sodium/lib/Crypto/Sodium/Salt.hs
@@ -36,7 +36,7 @@ import qualified Language.Haskell.TH.Syntax as TH
 import qualified Crypto.Sodium.Nonce
 
 
--- | Make a /sized/ 'ByteString' from a type-level string literal.
+-- | Quasi-quoter to construct a /sized/ 'ByteString' literal.
 --
 -- @
 -- {-# LANGUAGE QuasiQuotes #-}

--- a/crypto-sodium/lib/Crypto/Sodium/Salt.hs
+++ b/crypto-sodium/lib/Crypto/Sodium/Salt.hs
@@ -1,0 +1,73 @@
+-- SPDX-FileCopyrightText: 2021 Serokell
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | This module gives different ways of obtaining salts.
+--
+-- A “salt” is additional input provided to certain functions.
+-- Unlike a nonce, salt is used for “namespacing”, so there is not
+-- requirement that it is used only once, instead you use different
+-- salts to deisgnate different applications of an algorithm.
+--
+-- This is a subtle and pure semantical difference, so, for convenience,
+-- we also re-export some functions from "Crypto.Sodium.Nonce".
+module Crypto.Sodium.Salt
+  (
+  -- * Literals
+    utf8
+
+  -- * Random salt generation
+  , Crypto.Sodium.Nonce.generate
+  ) where
+
+import Data.ByteArray.Sized (SizedByteArray, unsafeSizedByteArray)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Internal as BS
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import Language.Haskell.TH (Exp, Q)
+import qualified Language.Haskell.TH.Lib as TH
+import Language.Haskell.TH.Quote (QuasiQuoter (..))
+import qualified Language.Haskell.TH.Syntax as TH
+
+import qualified Crypto.Sodium.Nonce
+
+
+-- | Make a /sized/ 'ByteString' from a type-level string literal.
+--
+-- @
+-- {-# LANGUAGE QuasiQuotes #-}
+--
+-- {- ... -}
+--
+-- let salt = [utf8|hello world|] :: 'SizedByteArray' 11 ByteString
+-- @
+--
+-- This uses Template Haskell to compute the length of the UTF-8 encoding
+-- of the string you provide. Note that the string will be taken as is,
+-- with all whitespace preserved, for example @[utf8| x |]@ will have length 3.
+utf8 :: QuasiQuoter
+utf8 = QuasiQuoter { quoteExp, quotePat, quoteType, quoteDec }
+  where
+    quoteExp :: String -> Q Exp
+    quoteExp str =
+        let
+          valExpr = [e|BS.packBytes $(TH.lift $ BS.unpackBytes bs)|]
+
+          len = BS.length bs
+          t = [t|SizedByteArray $(TH.litT . TH.numTyLit . fromIntegral $ len) ByteString|]
+        in
+          -- This is really safe because, well, we compute the length.
+          [e|unsafeSizedByteArray $(valExpr) :: $(t)|]
+      where
+        bs :: ByteString
+        bs = T.encodeUtf8 $ T.pack str
+
+    err :: String -> Q a
+    err _ = fail "A `utf8` quasi-quotation can only be used as an expression"
+    quotePat = err
+    quoteType = err
+    quoteDec = err

--- a/crypto-sodium/package.yaml
+++ b/crypto-sodium/package.yaml
@@ -71,6 +71,8 @@ library:
     - cereal >= 0.1 && < 0.6
     - NaCl >= 0.0.4.0 && < 0.1
     - random >= 1.0 && < 1.3
+    - template-haskell >= 2.8.0.0 && < 2.19
+    - text >= 0.1 && < 1.3
 
 tests:
   test:

--- a/crypto-sodium/package.yaml
+++ b/crypto-sodium/package.yaml
@@ -73,6 +73,7 @@ library:
     - random >= 1.0 && < 1.3
     - template-haskell >= 2.16.0.0 && < 2.19
     - text >= 0.1 && < 1.3
+    - th-compat >= 0.1.2 && < 0.2
 
 tests:
   test:

--- a/crypto-sodium/package.yaml
+++ b/crypto-sodium/package.yaml
@@ -71,7 +71,7 @@ library:
     - cereal >= 0.1 && < 0.6
     - NaCl >= 0.0.4.0 && < 0.1
     - random >= 1.0 && < 1.3
-    - template-haskell >= 2.8.0.0 && < 2.19
+    - template-haskell >= 2.16.0.0 && < 2.19
     - text >= 0.1 && < 1.3
 
 tests:

--- a/crypto-sodium/test/Test/Crypto/Sodium/Hash.hs
+++ b/crypto-sodium/test/Test/Crypto/Sodium/Hash.hs
@@ -21,6 +21,7 @@ import Control.Monad (forM_)
 import qualified Libsodium as Na
 
 import qualified Crypto.Sodium.Hash as Hash
+import Crypto.Sodium.Key (generate)
 
 
 unit_blake2b256_unkeyed :: Assertion
@@ -30,6 +31,14 @@ unit_blake2b256_unkeyed = do
       Just hash = sizedByteArray . fromRight (error "impossible") . decodeBase16 $
           "9ec2c90ec850ccd1b924806046eace8dd3730e631ad8eb73c28b78abba936232"
     Hash.blake2b @32 msg @?= hash
+
+unit_blake2b256_generate_key :: Assertion
+unit_blake2b256_generate_key = do
+    let msg = "testing\n" :: ByteString
+    -- we just make sure that this typechecks, i.e. all type-level Nats align
+    key <- generate @32
+    let _out = Hash.blake2bWithKey @64 @ByteString key msg
+    pure ()
 
 
 blake2b_test_vector
@@ -44,7 +53,7 @@ blake2b_test_vector
   -> Assertion
 blake2b_test_vector msg key hash = do
   let hash' = fromRight (error "impossible") . decodeBase16 $ hash
-      key' = fromRight (error "impossible") . decodeBase16 $ key
+      Just key' = sizedByteArray @64 . fromRight (error "impossible") . decodeBase16 $ key
       msg' = fromRight (error "impossible") . decodeBase16 $ msg
       Just hash'N = sizedByteArray @len hash'
       result = Hash.blake2bWithKey key' msg'

--- a/crypto-sodium/test/Test/Crypto/Sodium/Hash.hs
+++ b/crypto-sodium/test/Test/Crypto/Sodium/Hash.hs
@@ -4,6 +4,7 @@
 
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -26,6 +27,7 @@ import qualified Libsodium as Na
 
 import qualified Crypto.Sodium.Hash as Hash
 import Crypto.Sodium.Key (generate)
+import Crypto.Sodium.Salt (utf8)
 
 
 unit_blake2b256_unkeyed :: Assertion
@@ -43,6 +45,15 @@ unit_blake2b512_generate_key = do
     key <- generate @32
     let _out = Hash.blake2bWithKey @64 @ByteString key msg
     pure ()
+
+unit_blake2b256_utf8_key :: Assertion
+unit_blake2b256_utf8_key = do
+    let
+      msg = "testing\n" :: ByteString
+      key = [utf8|hello|]
+      Just hash = sizedByteArray . fromRight (error "impossible") . decodeBase16 $
+          "649859ec1dd0ef538faae58eef9e2c701dc881ac5a1d6641113fad96e2fc1725"
+    Hash.blake2bWithKey @32 @ByteString key msg @?= hash
 
 hprop_blake2b256_empty_key :: Property
 hprop_blake2b256_empty_key = property $ do

--- a/crypto-sodium/test/Test/Crypto/Sodium/Hash.hs
+++ b/crypto-sodium/test/Test/Crypto/Sodium/Hash.hs
@@ -9,9 +9,13 @@
 
 module Test.Crypto.Sodium.Hash where
 
+import Hedgehog (Property, (===), forAll, property)
+import qualified Hedgehog.Gen as G
+import qualified Hedgehog.Range as R
 import Test.HUnit ((@?=), Assertion)
 
-import Data.ByteArray.Sized (sizedByteArray)
+import Data.ByteArray (Bytes)
+import Data.ByteArray.Sized (SizedByteArray, empty, sizedByteArray)
 import Data.ByteString (ByteString)
 import Data.ByteString.Base16 (decodeBase16)
 import Data.Either (fromRight)
@@ -32,13 +36,19 @@ unit_blake2b256_unkeyed = do
           "9ec2c90ec850ccd1b924806046eace8dd3730e631ad8eb73c28b78abba936232"
     Hash.blake2b @32 msg @?= hash
 
-unit_blake2b256_generate_key :: Assertion
-unit_blake2b256_generate_key = do
+unit_blake2b512_generate_key :: Assertion
+unit_blake2b512_generate_key = do
     let msg = "testing\n" :: ByteString
     -- we just make sure that this typechecks, i.e. all type-level Nats align
     key <- generate @32
     let _out = Hash.blake2bWithKey @64 @ByteString key msg
     pure ()
+
+hprop_blake2b256_empty_key :: Property
+hprop_blake2b256_empty_key = property $ do
+    let key = empty :: SizedByteArray 0 Bytes
+    msg <- forAll $ G.bytes (R.linear 0 1_000)
+    Hash.blake2bWithKey key msg === Hash.blake2b @32 @Bytes msg
 
 
 blake2b_test_vector

--- a/crypto-sodium/test/Test/Crypto/Sodium/Salt.hs
+++ b/crypto-sodium/test/Test/Crypto/Sodium/Salt.hs
@@ -1,0 +1,30 @@
+-- SPDX-FileCopyrightText: 2021 Serokell
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+{-# LANGUAGE QuasiQuotes #-}
+
+module Test.Crypto.Sodium.Salt where
+
+import Data.ByteArray.Sized (SizedByteArray, unSizedByteArray)
+import Data.ByteString (ByteString)
+
+import Test.HUnit ((@?=), Assertion)
+
+import Crypto.Sodium.Salt (utf8)
+
+
+unit_ascii_literal :: Assertion
+unit_ascii_literal = do
+    let lit = [utf8|hello|] :: SizedByteArray 5 ByteString
+    unSizedByteArray lit @?= "hello"
+
+unit_nonascii_literal :: Assertion
+unit_nonascii_literal = do
+    let lit = [utf8|привет|] :: SizedByteArray 12 ByteString
+    unSizedByteArray lit @?= "\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82"
+
+unit_space_literal :: Assertion
+unit_space_literal = do
+    let lit = [utf8|hello world|] :: SizedByteArray 11 ByteString
+    unSizedByteArray lit @?= "hello world"

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
               };
             })
           ];
-          ghcVersions = [ "884" "8107" "901" ];
+          ghcVersions = [ "8107" "901" ];
         };
 
       in flake


### PR DESCRIPTION
Supersedes #34. That PR already got too long, so here is the same thing once again. The only difference form the last version in that PR is that here we provide TH quasi-quoters for easy creation of literal salts:

```haskell
let salt = [utf8|hello world|] :: SizedByteArray 11 ByteString
```