### PR TITLE
Provide a way to create sized ByteStrings from strings of bytes

### DIFF
--- a/crypto-sodium/crypto-sodium.cabal
+++ b/crypto-sodium/crypto-sodium.cabal
@@ -86,6 +86,7 @@ library
       Crypto.Sodium.Pwhash.Internal
       Crypto.Sodium.Random
       Crypto.Sodium.Salt
+      Crypto.Sodium.Salt.Internal
       Crypto.Sodium.Sign
   other-modules:
       Paths_crypto_sodium

--- a/crypto-sodium/lib/Crypto/Sodium/Salt.hs
+++ b/crypto-sodium/lib/Crypto/Sodium/Salt.hs
@@ -18,13 +18,16 @@ module Crypto.Sodium.Salt
   (
   -- * Literals
     utf8
+  , bytes
 
   -- * Random salt generation
   , Crypto.Sodium.Nonce.generate
   ) where
 
+import Control.Monad ((<=<))
+import Data.Bits (toIntegralSized)
 import Data.ByteArray.Sized (SizedByteArray, unsafeSizedByteArray)
-import Data.ByteString (ByteString)
+import Data.ByteString (ByteString, pack)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as BS
 import qualified Data.Text as T
@@ -36,6 +39,8 @@ import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import Language.Haskell.TH.Syntax.Compat (SpliceQ)
 import qualified Language.Haskell.TH.Syntax.Compat as TH
 import System.IO.Unsafe (unsafeDupablePerformIO)
+import Text.ParserCombinators.ReadP (readP_to_S, many)
+import Text.Read.Lex (lexChar)
 
 import qualified Crypto.Sodium.Nonce
 
@@ -54,28 +59,64 @@ import qualified Crypto.Sodium.Nonce
 -- of the string you provide. Note that the string will be taken as is,
 -- with all whitespace preserved, for example @[utf8| x |]@ will have length 3.
 utf8 :: QuasiQuoter
-utf8 = QuasiQuoter { quoteExp, quotePat, quoteType, quoteDec }
+utf8 = mkQuoter "utf8" (pure . T.encodeUtf8 . T.pack)
+
+-- | Quasi-quoter to construct a /sized/ 'ByteString' literal. This quoter
+-- will parse Haskell character escapes, and interpret the quoted string as
+-- a sequence of bytes, rather than text.
+--
+-- @
+-- {-# LANGUAGE QuasiQuotes #-}
+--
+-- {- ... -}
+--
+-- let salt = [bytes|\xff\x00\xde|] :: 'SizedByteArray' 3 ByteString
+-- @
+--
+-- This uses Template Haskell to compute the length of the raw byte
+-- string you provide. Note that the string will be taken as is,
+-- with all whitespace preserved, for example @[bytes| x |]@ will have length 3.
+--
+-- The conversion rules are exactly the same as @OverloadedString@ rules for
+-- 'ByteString'. In particular, characters that are more than one byte wide
+-- will be silently truncated to one byte.
+bytes :: QuasiQuoter
+bytes = mkQuoter "bytes" (toBytes <=< parseEscapes)
+  where
+    toBytes = fmap pack . traverse charToByte
+    charToByte c =
+      let msg = "Character does not fit into a byte: '" <> [c] <> "' (" <> show c <> ")"
+      in maybe (fail msg) pure $ toIntegralSized (fromEnum c)
+    parseEscapes str = case reverse (readP_to_S (many lexChar) str) of
+      (result, ""):_ -> pure result
+      (_, rest):_ -> fail $ "Failed to parse raw bytes: " <> rest
+      [] -> fail $ "Failed to parse raw bytes (no parse): " <> str
+
+-- | A helper function to construct a quasi-quoter making a sized byte array
+-- given a conversion from 'String' to 'ByteString'.
+mkQuoter :: String -> (String -> Q ByteString) -> QuasiQuoter
+mkQuoter name convert = QuasiQuoter { quoteExp, quotePat, quoteType, quoteDec }
   where
     quoteExp :: String -> Q Exp
-    quoteExp str = [e|unsafeSizedByteArray $(TH.unTypeSplice bsSplice) :: $tSized|]
-      where
-        bs :: ByteString
-        bs = T.encodeUtf8 $ T.pack str
+    quoteExp str = do
+      bs <- convert str
+      let len = BS.length bs
+          tSized = mkTSized len
+          bsSplice = mkBsSplice len bs
+      [e|unsafeSizedByteArray $(TH.unTypeSplice bsSplice) :: $tSized|]
 
-        len :: Int
-        len = BS.length bs
+    mkBsSplice :: Int -> ByteString -> SpliceQ ByteString
+    mkBsSplice len bs =
+      let cstrSplice :: SpliceQ Addr#
+          cstrSplice = TH.unsafeSpliceCoerce . TH.litE . TH.stringPrimL . BS.unpack $ bs
+      in [e||unsafeDupablePerformIO $ BS.unsafePackAddressLen len $$cstrSplice||]
 
-        cstrSplice :: SpliceQ Addr#
-        cstrSplice = TH.unsafeSpliceCoerce . TH.litE . TH.stringPrimL . BS.unpack $ bs
-
-        bsSplice :: SpliceQ ByteString
-        bsSplice = [e||unsafeDupablePerformIO $ BS.unsafePackAddressLen len $$cstrSplice||]
-
-        tSized :: Q Type
-        tSized = [t|SizedByteArray $(TH.litT . TH.numTyLit . fromIntegral $ len) ByteString|]
+    mkTSized :: Int -> Q Type
+    mkTSized len = [t|SizedByteArray $(TH.litT . TH.numTyLit . fromIntegral $ len) ByteString|]
 
     err :: String -> Q a
-    err _ = fail "A `utf8` quasi-quotation can only be used as an expression"
+    err _ = fail $ "A `" <> name <> "` quasi-quotation can only be used as an expression"
+
     quotePat = err
     quoteType = err
     quoteDec = err

--- a/crypto-sodium/lib/Crypto/Sodium/Salt.hs
+++ b/crypto-sodium/lib/Crypto/Sodium/Salt.hs
@@ -30,7 +30,6 @@ import Data.ByteArray.Sized (SizedByteArray, unsafeSizedByteArray)
 import Data.ByteString (ByteString, pack)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as BS
-import Data.Maybe (listToMaybe)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import GHC.Exts (Addr#)
@@ -40,10 +39,9 @@ import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import Language.Haskell.TH.Syntax.Compat (SpliceQ)
 import qualified Language.Haskell.TH.Syntax.Compat as TH
 import System.IO.Unsafe (unsafeDupablePerformIO)
-import Text.ParserCombinators.ReadP (eof, readP_to_S, many)
-import Text.Read.Lex (lexChar)
 
 import qualified Crypto.Sodium.Nonce
+import Crypto.Sodium.Salt.Internal (parseEscapes)
 
 
 -- | Quasi-quoter to construct a /sized/ 'ByteString' from string literal
@@ -126,15 +124,3 @@ mkQuoter name convert = QuasiQuoter { quoteExp, quotePat, quoteType, quoteDec }
     quotePat = err
     quoteType = err
     quoteDec = err
-
--- | Parse a Haskell string literal with escapes.
---
--- Given a string similar to what a Haskell compiler can see between double quotes,
--- process escape sequences according to the Haskell standard and return
--- the resulting string.
---
--- This function can fail if there are invalid escape sequences.
-parseEscapes :: MonadFail m => String -> m String
-parseEscapes str = case listToMaybe (readP_to_S (many lexChar <* eof) str) of
-  Just (result, "") -> pure result
-  _ -> fail $ "Failed to parse raw bytes (no parse): " <> str

--- a/crypto-sodium/lib/Crypto/Sodium/Salt/Internal.hs
+++ b/crypto-sodium/lib/Crypto/Sodium/Salt/Internal.hs
@@ -1,0 +1,24 @@
+-- SPDX-FileCopyrightText: 2021 Serokell
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+-- | Internal utilities for "Crypto.Sodium.Salt".
+module Crypto.Sodium.Salt.Internal
+  ( parseEscapes
+  ) where
+
+import Data.Maybe (listToMaybe)
+import Text.ParserCombinators.ReadP (eof, readP_to_S, many)
+import Text.Read.Lex (lexChar)
+
+-- | Parse a Haskell string literal with escapes.
+--
+-- Given a string similar to what a Haskell compiler can see between double quotes,
+-- process escape sequences according to the Haskell standard and return
+-- the resulting string.
+--
+-- This function can fail if there are invalid escape sequences.
+parseEscapes :: MonadFail m => String -> m String
+parseEscapes str = case listToMaybe (readP_to_S (many lexChar <* eof) str) of
+  Just (result, "") -> pure result
+  _ -> fail $ "Failed to parse raw bytes (no parse): " <> str

--- a/crypto-sodium/test/Test/Crypto/Sodium/Salt.hs
+++ b/crypto-sodium/test/Test/Crypto/Sodium/Salt.hs
@@ -11,7 +11,7 @@ import Data.ByteString (ByteString)
 
 import Test.HUnit ((@?=), Assertion)
 
-import Crypto.Sodium.Salt (utf8)
+import Crypto.Sodium.Salt (utf8, bytes)
 
 
 unit_ascii_literal :: Assertion
@@ -28,3 +28,8 @@ unit_space_literal :: Assertion
 unit_space_literal = do
     let lit = [utf8|hello world|] :: SizedByteArray 11 ByteString
     unSizedByteArray lit @?= "hello world"
+
+unit_raw_byte_literal :: Assertion
+unit_raw_byte_literal = do
+    let lit = [bytes|z\x00\xff\SOH\1\&2|] :: SizedByteArray 6 ByteString
+    unSizedByteArray lit @?= "z\x00\xff\SOH\1\&2"

--- a/crypto-sodium/test/Test/Crypto/Sodium/Salt.hs
+++ b/crypto-sodium/test/Test/Crypto/Sodium/Salt.hs
@@ -14,22 +14,33 @@ import Test.HUnit ((@?=), Assertion)
 import Crypto.Sodium.Salt (utf8, bytes)
 
 
-unit_ascii_literal :: Assertion
-unit_ascii_literal = do
+unit_utf8_ascii_literal :: Assertion
+unit_utf8_ascii_literal = do
     let lit = [utf8|hello|] :: SizedByteArray 5 ByteString
     unSizedByteArray lit @?= "hello"
 
-unit_nonascii_literal :: Assertion
-unit_nonascii_literal = do
+unit_utf8_nonascii_literal :: Assertion
+unit_utf8_nonascii_literal = do
     let lit = [utf8|привет|] :: SizedByteArray 12 ByteString
     unSizedByteArray lit @?= "\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82"
 
-unit_space_literal :: Assertion
-unit_space_literal = do
+unit_utf8_space_literal :: Assertion
+unit_utf8_space_literal = do
     let lit = [utf8|hello world|] :: SizedByteArray 11 ByteString
     unSizedByteArray lit @?= "hello world"
 
-unit_raw_byte_literal :: Assertion
-unit_raw_byte_literal = do
+unit_utf8_escapes :: Assertion
+unit_utf8_escapes = do
+    let lit = [utf8|ĝis\x0021\r\n|] :: SizedByteArray 7 ByteString
+    unSizedByteArray lit @?= "\xc4\x9dis!\r\n"
+
+
+unit_bytes_literal :: Assertion
+unit_bytes_literal = do
+    let lit = [bytes|hi\n\x00|] :: SizedByteArray 4 ByteString
+    unSizedByteArray lit @?= "hi\n\x00"
+
+unit_bytes_literal_2 :: Assertion
+unit_bytes_literal_2 = do
     let lit = [bytes|z\x00\xff\SOH\1\&2|] :: SizedByteArray 6 ByteString
     unSizedByteArray lit @?= "z\x00\xff\SOH\1\&2"


### PR DESCRIPTION
I've realized we need something like this as well, because Tezos also uses "\x00\xff\x00\xff..." as a "salt".

Add a QuasiQuoter that takes a string, parses Haskell character escape codes,
interprets the result as a list of raw bytes (truncating any characters
that do not fit into bytes, like `OverloadedString` implementation for `ByteString`),
and constructs a sized byte array from that.

... now note we could actually check if characters fit into bytes and throw an error/warning if they don't. Let me know what you think.